### PR TITLE
cmdline.cc add ANYID

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -633,6 +633,10 @@ shared_ptr<Configuration> parseCommandLine(int argc, char **argv) {
         else
         {
             // WMBus ids are 8 hex digits iiiiiiii
+            if (id == "ANYID") {
+            id = "*";
+            return true;
+            }
             if (!isValidMatchExpressions(id, true)) error("Not a valid id nor a valid meter match expression \"%s\"\n", id.c_str());
         }
         if (!isValidKey(key, mi.driver)) error("Not a valid meter key \"%s\"\n", key.c_str());


### PR DESCRIPTION
add Support for ANYID / NOID as substitute for * meter_id, as * dont work with variables
fixes https://github.com/weetmuts/wmbusmeters/issues/428